### PR TITLE
mdlcolor for leaves & bushes

### DIFF
--- a/vegetation/acacia/acacia1/lod1/obj.cfg
+++ b/vegetation/acacia/acacia1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia1/lod2/obj.cfg
+++ b/vegetation/acacia/acacia1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia1/obj.cfg
+++ b/vegetation/acacia/acacia1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../acacia.png
 objbumpmap acacia ../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../brake03.png
 objbumpmap brake03 ../brake03_n.png

--- a/vegetation/acacia/acacia2/lod1/obj.cfg
+++ b/vegetation/acacia/acacia2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia2/lod2/obj.cfg
+++ b/vegetation/acacia/acacia2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia2/obj.cfg
+++ b/vegetation/acacia/acacia2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../acacia.png
 objbumpmap acacia ../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../brake03.png
 objbumpmap brake03 ../brake03_n.png

--- a/vegetation/acacia/acacia3/lod1/obj.cfg
+++ b/vegetation/acacia/acacia3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia3/lod2/obj.cfg
+++ b/vegetation/acacia/acacia3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../../acacia.png
 objbumpmap acacia ../../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../../brake03.png
 objbumpmap brake03 ../../brake03_n.png

--- a/vegetation/acacia/acacia3/obj.cfg
+++ b/vegetation/acacia/acacia3/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin acacia ../acacia.png
 objbumpmap acacia ../acacia_n.png
+objcolor acacia -1
 
 objskin brake03 ../brake03.png
 objbumpmap brake03 ../brake03_n.png

--- a/vegetation/beech/beech1/lod1/obj.cfg
+++ b/vegetation/beech/beech1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech1/lod2/obj.cfg
+++ b/vegetation/beech/beech1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech1/obj.cfg
+++ b/vegetation/beech/beech1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/beech/beech2/lod1/obj.cfg
+++ b/vegetation/beech/beech2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech2/lod2/obj.cfg
+++ b/vegetation/beech/beech2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech2/obj.cfg
+++ b/vegetation/beech/beech2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/beech/beech3/lod1/obj.cfg
+++ b/vegetation/beech/beech3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech3/lod2/obj.cfg
+++ b/vegetation/beech/beech3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/beech/beech3/obj.cfg
+++ b/vegetation/beech/beech3/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/birch/birch1/lod1/obj.cfg
+++ b/vegetation/birch/birch1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch1/lod2/obj.cfg
+++ b/vegetation/birch/birch1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch1/obj.cfg
+++ b/vegetation/birch/birch1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../birch_leaf.png
 objbumpmap birch_leaf ../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../bark04.png
 objbumpmap bark04 ../bark04_n.png

--- a/vegetation/birch/birch2/lod1/obj.cfg
+++ b/vegetation/birch/birch2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch2/lod2/obj.cfg
+++ b/vegetation/birch/birch2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch2/obj.cfg
+++ b/vegetation/birch/birch2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../birch_leaf.png
 objbumpmap birch_leaf ../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../bark04.png
 objbumpmap bark04 ../bark04_n.png

--- a/vegetation/birch/birch3/lod1/obj.cfg
+++ b/vegetation/birch/birch3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch3/lod2/obj.cfg
+++ b/vegetation/birch/birch3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../../birch_leaf.png
 objbumpmap birch_leaf ../../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../../bark04.png
 objbumpmap bark04 ../../bark04_n.png

--- a/vegetation/birch/birch3/obj.cfg
+++ b/vegetation/birch/birch3/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin birch_leaf ../birch_leaf.png
 objbumpmap birch_leaf ../birch_leaf_n.png
+objcolor birch_leaf -1
 
 objskin bark04 ../bark04.png
 objbumpmap bark04 ../bark04_n.png

--- a/vegetation/bush/bush1/lod1/obj.cfg
+++ b/vegetation/bush/bush1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/bush/bush1/obj.cfg
+++ b/vegetation/bush/bush1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/bush/bush2/lod1/obj.cfg
+++ b/vegetation/bush/bush2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/bush/bush2/obj.cfg
+++ b/vegetation/bush/bush2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/bush/bush3/lod1/obj.cfg
+++ b/vegetation/bush/bush3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../../beech_leaf.png
 objbumpmap beech_leaf ../../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/bush/bush3/obj.cfg
+++ b/vegetation/bush/bush3/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin beech_leaf ../beech_leaf.png
 objbumpmap beech_leaf ../beech_leaf_n.png
+objcolor beech_leaf -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/bush/bush4/lod1/obj.cfg
+++ b/vegetation/bush/bush4/lod1/obj.cfg
@@ -1,6 +1,7 @@
 objload mesh.obj
 
 objskin leaf12 ../../leaf12.png
+objcolor leaf12 -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/bush/bush4/lod2/obj.cfg
+++ b/vegetation/bush/bush4/lod2/obj.cfg
@@ -1,6 +1,7 @@
 objload mesh.obj
 
 objskin leaf12 ../../leaf12.png
+objcolor leaf12 -1
 
 objskin bark01 ../../bark01.png
 objbumpmap bark01 ../../bark01_n.png

--- a/vegetation/bush/bush4/obj.cfg
+++ b/vegetation/bush/bush4/obj.cfg
@@ -1,6 +1,7 @@
 objload mesh.obj
 
 objskin leaf12 ../leaf12.png
+objcolor leaf12 -1
 
 objskin bark01 ../bark01.png
 objbumpmap bark01 ../bark01_n.png

--- a/vegetation/coconut_palm/coconut_palm1/lod1/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm1/lod2/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm1/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm1/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../coconut_palm_leaf_n.png
+objnoclip coconut_palm_leaf 1
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../palm03.png
 objbumpmap palm03 ../palm03_n.png
@@ -11,7 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip coconut_palm_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/coconut_palm/coconut_palm2/lod1/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm2/lod2/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm2/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm2/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../coconut_palm_leaf_n.png
+objnoclip coconut_palm_leaf 1
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../palm03.png
 objbumpmap palm03 ../palm03_n.png
@@ -11,7 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip coconut_palm_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/coconut_palm/coconut_palm3/lod1/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm3/lod2/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../../coconut_palm_leaf_n.png
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../../palm03.png
 objbumpmap palm03 ../../palm03_n.png

--- a/vegetation/coconut_palm/coconut_palm3/obj.cfg
+++ b/vegetation/coconut_palm/coconut_palm3/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin coconut_palm_leaf ../coconut_palm_leaf.png
 objbumpmap coconut_palm_leaf ../coconut_palm_leaf_n.png
+objnoclip coconut_palm_leaf 1
+objcolor coconut_palm_leaf -1
 
 objskin palm03 ../palm03.png
 objbumpmap palm03 ../palm03_n.png
@@ -11,7 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip coconut_palm_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/hanging_leaves/hanging_leaves1/lod1/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../../leaf.png
 objbumpmap leaf ../../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../../stem.png
 objbumpmap stem ../../stem_n.png

--- a/vegetation/hanging_leaves/hanging_leaves1/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,6 +12,7 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 188
+mdlbb 4
+
 mdllod lod1 750

--- a/vegetation/hanging_leaves/hanging_leaves2/lod1/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../../leaf.png
 objbumpmap leaf ../../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../../stem.png
 objbumpmap stem ../../stem_n.png

--- a/vegetation/hanging_leaves/hanging_leaves2/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,6 +12,7 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 188
+mdlbb 4
+
 mdllod lod1 750

--- a/vegetation/hanging_leaves/hanging_leaves3/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves3/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 188
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves4/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves4/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 188
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves5/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves5/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 188
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves6/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves6/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 180
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves7/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves7/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 180
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves8/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves8/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,5 +12,5 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 180
+mdlbb 4

--- a/vegetation/hanging_leaves/hanging_leaves9/lod1/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves9/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../../leaf.png
 objbumpmap leaf ../../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../../stem.png
 objbumpmap stem ../../stem_n.png
@@ -11,5 +12,4 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 180

--- a/vegetation/hanging_leaves/hanging_leaves9/obj.cfg
+++ b/vegetation/hanging_leaves/hanging_leaves9/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin leaf ../leaf.png
 objbumpmap leaf ../leaf_n.png
+objcolor leaf -1
 
 objskin stem ../stem.png
 objbumpmap stem ../stem_n.png
@@ -11,6 +12,7 @@ mdlspec 100
 mdlalphatest 0.7
 mdlwind 0.25
 mdlcollide 0
-
 mdlpitch 180
+mdlbb 4
+
 mdllod lod1 750

--- a/vegetation/maple/maple1/lod1/obj.cfg
+++ b/vegetation/maple/maple1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple1/lod2/obj.cfg
+++ b/vegetation/maple/maple1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple1/obj.cfg
+++ b/vegetation/maple/maple1/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin maple_leaf ../maple_leaf.png
 objbumpmap maple_leaf ../maple_leaf_n.png
+objnoclip maple_leaf 1
+objcolor maple_leaf -1
 
 objskin bark05 ../bark05.png
 objbumpmap bark05 ../bark05_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip maple_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/maple/maple2/lod1/obj.cfg
+++ b/vegetation/maple/maple2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple2/lod2/obj.cfg
+++ b/vegetation/maple/maple2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple2/obj.cfg
+++ b/vegetation/maple/maple2/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin maple_leaf ../maple_leaf.png
 objbumpmap maple_leaf ../maple_leaf_n.png
+objnoclip maple_leaf 1
+objcolor maple_leaf -1
 
 objskin bark05 ../bark05.png
 objbumpmap bark05 ../bark05_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip maple_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/maple/maple3/lod1/obj.cfg
+++ b/vegetation/maple/maple3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple3/lod2/obj.cfg
+++ b/vegetation/maple/maple3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin maple_leaf ../../maple_leaf.png
 objbumpmap maple_leaf ../../maple_leaf_n.png
+objcolor maple_leaf -1
 
 objskin bark05 ../../bark05.png
 objbumpmap bark05 ../../bark05_n.png

--- a/vegetation/maple/maple3/obj.cfg
+++ b/vegetation/maple/maple3/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin maple_leaf ../maple_leaf.png
 objbumpmap maple_leaf ../maple_leaf_n.png
+objnoclip maple_leaf 1
+objcolor maple_leaf -1
 
 objskin bark05 ../bark05.png
 objbumpmap bark05 ../bark05_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip maple_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/oak/oak1/lod1/obj.cfg
+++ b/vegetation/oak/oak1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin oak_leaf ../../oak_leaf.png
 objbumpmap oak_leaf ../../oak_leaf_n.png
+objcolor oak_leaf -1
 
 objskin bark03 ../../bark03.png
 objbumpmap bark03 ../../bark03_n.png
@@ -10,8 +11,6 @@ mdlscale 100
 mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
-mdltricollide 1
-objnoclip oak_leaf 1
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/oak/oak1/lod2/obj.cfg
+++ b/vegetation/oak/oak1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin oak_leaf ../../oak_leaf.png
 objbumpmap oak_leaf ../../oak_leaf_n.png
+objcolor oak_leaf -1
 
 objskin bark03 ../../bark03.png
 objbumpmap bark03 ../../bark03_n.png
@@ -10,8 +11,6 @@ mdlscale 100
 mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
-mdltricollide 1
-objnoclip oak_leaf 1
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/oak/oak1/obj.cfg
+++ b/vegetation/oak/oak1/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin oak_leaf ../oak_leaf.png
 objbumpmap oak_leaf ../oak_leaf_n.png
+objnoclip oak_leaf 1
+objcolor oak_leaf -1
 
 objskin bark03 ../bark03.png
 objbumpmap bark03 ../bark03_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip oak_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/oak/oak2/lod1/obj.cfg
+++ b/vegetation/oak/oak2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin oak_leaf ../../oak_leaf.png
 objbumpmap oak_leaf ../../oak_leaf_n.png
+objcolor oak_leaf -1
 
 objskin bark03 ../../bark03.png
 objbumpmap bark03 ../../bark03_n.png
@@ -10,8 +11,6 @@ mdlscale 100
 mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
-mdltricollide 1
-objnoclip oak_leaf 1
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/oak/oak2/lod2/obj.cfg
+++ b/vegetation/oak/oak2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin oak_leaf ../../oak_leaf.png
 objbumpmap oak_leaf ../../oak_leaf_n.png
+objcolor oak_leaf -1
 
 objskin bark03 ../../bark03.png
 objbumpmap bark03 ../../bark03_n.png
@@ -10,8 +11,6 @@ mdlscale 100
 mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
-mdltricollide 1
-objnoclip oak_leaf 1
 
 mdllod lod1 750
 mdllod lod2 1250

--- a/vegetation/oak/oak2/obj.cfg
+++ b/vegetation/oak/oak2/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin oak_leaf ../oak_leaf.png
 objbumpmap oak_leaf ../oak_leaf_n.png
+objnoclip oak_leaf 1
+objcolor oak_leaf -1
 
 objskin bark03 ../bark03.png
 objbumpmap bark03 ../bark03_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip oak_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce1/lod1/obj.cfg
+++ b/vegetation/spruce/spruce1/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce1/lod2/obj.cfg
+++ b/vegetation/spruce/spruce1/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce1/obj.cfg
+++ b/vegetation/spruce/spruce1/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce2/lod1/obj.cfg
+++ b/vegetation/spruce/spruce2/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce2/lod2/obj.cfg
+++ b/vegetation/spruce/spruce2/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce2/obj.cfg
+++ b/vegetation/spruce/spruce2/obj.cfg
@@ -2,8 +2,11 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../spruce_leaf_dead.png
+objnoclip spruce_leaf_dead 1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -13,9 +16,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
-objnoclip spruce_leaf_dead 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce3/lod1/obj.cfg
+++ b/vegetation/spruce/spruce3/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce3/lod2/obj.cfg
+++ b/vegetation/spruce/spruce3/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce3/obj.cfg
+++ b/vegetation/spruce/spruce3/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce4/lod1/obj.cfg
+++ b/vegetation/spruce/spruce4/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce4/lod2/obj.cfg
+++ b/vegetation/spruce/spruce4/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce4/obj.cfg
+++ b/vegetation/spruce/spruce4/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce5/lod1/obj.cfg
+++ b/vegetation/spruce/spruce5/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce5/lod2/obj.cfg
+++ b/vegetation/spruce/spruce5/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce5/obj.cfg
+++ b/vegetation/spruce/spruce5/obj.cfg
@@ -2,8 +2,11 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../spruce_leaf_dead.png
+objnoclip spruce_leaf_dead 1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -13,9 +16,8 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
-objnoclip spruce_leaf_dead 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4
+

--- a/vegetation/spruce/spruce6/lod1/obj.cfg
+++ b/vegetation/spruce/spruce6/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce6/lod2/obj.cfg
+++ b/vegetation/spruce/spruce6/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin bark06 ../../bark06.png
 objbumpmap bark06 ../../bark06_n.png

--- a/vegetation/spruce/spruce6/obj.cfg
+++ b/vegetation/spruce/spruce6/obj.cfg
@@ -2,6 +2,8 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -11,8 +13,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce7/lod1/obj.cfg
+++ b/vegetation/spruce/spruce7/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce7/lod2/obj.cfg
+++ b/vegetation/spruce/spruce7/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce7/obj.cfg
+++ b/vegetation/spruce/spruce7/obj.cfg
@@ -2,8 +2,11 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../spruce_leaf_dead.png
+objnoclip spruce_leaf_dead 1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -13,9 +16,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
-objnoclip spruce_leaf_dead 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4

--- a/vegetation/spruce/spruce8/lod1/obj.cfg
+++ b/vegetation/spruce/spruce8/lod1/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce8/lod2/obj.cfg
+++ b/vegetation/spruce/spruce8/lod2/obj.cfg
@@ -2,6 +2,7 @@ objload mesh.obj
 
 objskin spruce_leaf ../../spruce_leaf.png
 objbumpmap spruce_leaf ../../spruce_leaf_n.png
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../../spruce_leaf_dead.png
 

--- a/vegetation/spruce/spruce8/obj.cfg
+++ b/vegetation/spruce/spruce8/obj.cfg
@@ -2,8 +2,11 @@ objload mesh.obj
 
 objskin spruce_leaf ../spruce_leaf.png
 objbumpmap spruce_leaf ../spruce_leaf_n.png
+objnoclip spruce_leaf 1
+objcolor spruce_leaf -1
 
 objskin spruce_leaf_dead ../spruce_leaf_dead.png
+objnoclip spruce_leaf_dead 1
 
 objskin bark06 ../bark06.png
 objbumpmap bark06 ../bark06_n.png
@@ -13,9 +16,7 @@ mdlspec 100
 mdlalphatest 0.25
 mdlwind 0.5
 mdltricollide 1
-objnoclip spruce_leaf 1
-objnoclip spruce_leaf_dead 1
+mdlbb 4
 
 mdllod lod1 750
 mdllod lod2 1250
-mdlbb 4


### PR DESCRIPTION
added: /mdlcolor commands for all trees and bushes, to allow changing their shade/color. For trees applies only to leaves sections.

added: missing mdlbb on coconut palms and hanging_leaves